### PR TITLE
Add missing mbed_hal_init() function

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-hal-st-stm32f429zi",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "mbed HAL for stm32f429zi microcontrollers",
   "keywords": [],
   "author": "Brendan Moran <brendan.moran@arm.com>",

--- a/source/init_api.c
+++ b/source/init_api.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2015 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed-hal/init_api.h"
+
+void mbed_hal_init(void)
+{
+    // not used for stm32f4
+}


### PR DESCRIPTION
This fixes the linker from failing:
`mbed-drivers/source/retarget.cpp:438: undefined reference to 'mbed_hal_init'`

@0xc0170 @bremoran 
