### PR TITLE
Bumped dependency version on uvisor-lib

### DIFF
--- a/module.json
+++ b/module.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "cmsis-core": "~0.2.0",
-    "uvisor-lib": "~0.7.0"
+    "uvisor-lib": "~0.8.0"
   },
   "targetDependencies": {}
 }


### PR DESCRIPTION
Requires https://github.com/ARMmbed/target-st-stm32f429i-disco/pull/9 to bu merged, bumped and published
@bremoran @autopulated 