### PR TITLE
Implement asynchronous SPI interface

### DIFF
--- a/mbed-hal-st-stm32f429zi/PeripheralNames.h
+++ b/mbed-hal-st-stm32f429zi/PeripheralNames.h
@@ -68,7 +68,7 @@ typedef enum {
     SPI_3 = (int)SPI3_BASE,
     SPI_4 = (int)SPI4_BASE,
     SPI_5 = (int)SPI5_BASE,
-    SPI_6 = (int)SPI5_BASE
+    SPI_6 = (int)SPI6_BASE
 } SPIName;
 
 typedef enum {

--- a/mbed-hal-st-stm32f429zi/device.h
+++ b/mbed-hal-st-stm32f429zi/device.h
@@ -45,6 +45,7 @@
 #define DEVICE_I2CSLAVE         1
 
 #define DEVICE_SPI              1
+#define DEVICE_SPI_ASYNCH       1
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1

--- a/mbed-hal-st-stm32f429zi/objects.h
+++ b/mbed-hal-st-stm32f429zi/objects.h
@@ -78,15 +78,12 @@ struct serial_s {
 };
 
 struct spi_s {
-    SPIName spi;
-    uint32_t bits;
-    uint32_t cpol;
-    uint32_t cpha;
-    uint32_t order;
-    uint32_t br_presc;
     PinName pin_miso;
     PinName pin_mosi;
     PinName pin_sclk;
+    PinName pin_ssel;
+    uint32_t event;
+    uint8_t module;
 };
 
 struct i2c_s {

--- a/mbed-hal-st-stm32f429zi/objects.h
+++ b/mbed-hal-st-stm32f429zi/objects.h
@@ -84,6 +84,7 @@ struct spi_s {
     PinName pin_ssel;
     uint32_t event;
     uint8_t module;
+    uint8_t transfer_type;
 };
 
 struct i2c_s {

--- a/mbed-hal-st-stm32f429zi/target_config.h
+++ b/mbed-hal-st-stm32f429zi/target_config.h
@@ -21,4 +21,9 @@
 #define MINAR_PLATFORM_TIME_BASE  1000
 #define MINAR_PLATFORM_MINIMUM_SLEEP 1
 
+#define MODULE_SIZE_SPI         6
+
+// Transaction queue size for each peripheral
+#define TRANSACTION_QUEUE_SIZE_SPI   16
+
 #endif


### PR DESCRIPTION
This restructures the `spi_s` object and adds the required defines.

The counterpart of this is in https://github.com/ARMmbed/mbed-hal-st-stm32f4/pull/15.

@bremoran @bogdanm @0xc0170 