### PR TITLE
Target Config: Set for 0.5ms lp timer tick.

### DIFF
--- a/mbed-hal-st-stm32f429zi/target_config.h
+++ b/mbed-hal-st-stm32f429zi/target_config.h
@@ -18,7 +18,7 @@
 
 // Minar platform configuration
 
-#define MINAR_PLATFORM_TIME_BASE  1000
+#define MINAR_PLATFORM_TIME_BASE  2000
 #define MINAR_PLATFORM_MINIMUM_SLEEP 1
 
 #define MODULE_SIZE_SPI         6


### PR DESCRIPTION
Complementary changes to https://github.com/ARMmbed/mbed-hal-st-stm32f4/pull/21.

Fixes https://github.com/ARMmbed/mbed-hal-st-stm32f4/issues/20.

@bogdanm @bremoran @0xc0170 