### PR TITLE
Moved uvisor_init before SystemInit

### DIFF
--- a/source/bootstrap_gcc/startup_stm32f429xx.s
+++ b/source/bootstrap_gcc/startup_stm32f429xx.s
@@ -108,9 +108,11 @@ LoopFillZerobss:
   bcc  FillZerobss
 
 /* Call the clock system intitialization function.*/
-  bl  SystemInit
 /* Call uVisor initialization function. */
+  bl SystemInitPre
+  bl HAL_InitPre
   bl uvisor_init
+  bl SystemInit
 /* Call static constructors */
   //bl __libc_init_array
 /* Call the application's entry point.*/


### PR DESCRIPTION
Code that must be run before uVisor will be kept in a separate function, SystemInitPre

@bogdanm 
@meriac 

Depends on: [updating]