### PR TITLE
Updated dependency on latest uvisor-lib

### DIFF
--- a/module.json
+++ b/module.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "cmsis-core": "^1.0.0",
-    "uvisor-lib": "^1.0.2",
+    "uvisor-lib": ">=1.0.0,<3.0.0",
     "mbed-hal-st-stm32f4": ">=1.0.4"
   },
   "targetDependencies": {}


### PR DESCRIPTION
uvisor-lib 2.0.0 was just released. This commit updates the dependency
on uvisor-lib to take into account this version.

@0xc0170 @bogdanm 